### PR TITLE
[iOS]Add support for Cordova 4.x.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,6 +38,8 @@
         <framework src="libsqlite3.dylib" />
         <framework src="Foundation.framework" weak="true" />
 
+        <dependency id="cordova-plugin-device" />
+
         <config-file target="*-Info.plist" parent="apiKey">
             <string>$API_KEY</string>
         </config-file>


### PR DESCRIPTION
**Description:**
Fix compiler error when building AB project (using Cordova v4.x or later) with latest plugin (v2.0.0).

> Fix compiler error.
> Add 'cordova-plugin-device' as dependency and use it to get the uid value.
> Otherwise fallback to UIDevice's 'identifierForVendor' method.
> See [API Changes in cordova-ios-4.0](https://github.com/apache/cordova-ios/blob/master/guides/API%20changes%20in%204.0.md) for more details regarding API changes.

**TeamPulse:** [[Plugins][iOS] iOS Build for Cordova 5.0 fails with Telerik Analytics plugin](http://teampulse.telerik.com/view#item/315412)
**Tests Report:** [MarketPluginTests Report](http://ice-qajenkins:8080/view/Samples+Plugins/job/CLI_Build_Marketplace_Combo_Plugins_LIN/138/HTML_Report_and_Logs/)
